### PR TITLE
updated the insert query in admin feature

### DIFF
--- a/applications/admin/utils/db_utils.py
+++ b/applications/admin/utils/db_utils.py
@@ -49,6 +49,7 @@ def add_user_details(engine: Engine, user_info: UserInput):
         email = user_info.email,
         hashed_password=pw,
         password=random_string,
+        previous_passwords=[],
         jobrole = user_info.jobrole,
         isd=user_info.isd,
         mobile_number=user_info.mobile_number


### PR DESCRIPTION
 directly inserted an empty list through the insert query, in previous_passwords column in the database without mentioning the previous_passwords element  in the request pydantic model